### PR TITLE
Fix track data path references

### DIFF
--- a/list-tracks.js
+++ b/list-tracks.js
@@ -12,7 +12,7 @@ function main() {
   const filterTag = args[0];
 
   try {
-    const tracksPath = 'assets/js/tracks.json';
+    const tracksPath = 'assets/audio/tracks.json';
     if (!fs.existsSync(tracksPath)) {
       console.log('❌ tracks.json not found');
       return;
@@ -58,7 +58,7 @@ function main() {
   }
 }
 
-if (!fs.existsSync('assets/js/tracks.json')) {
+if (!fs.existsSync('assets/audio/tracks.json')) {
   console.error('❌ Error: Please run this script from the website root directory');
   process.exit(1);
 }

--- a/projects/not-today-darling.html
+++ b/projects/not-today-darling.html
@@ -1048,7 +1048,7 @@
   </div>
 
   <script src="../assets/js/enhancements.js?v=20250210"></script>
-  <script src="../assets/js/music.js?v=20250926"></script>
+  <script src="../assets/js/pages/music.js?v=20250926"></script>
   <script src="../assets/js/pages/not-today-darling.js" defer></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -40,7 +40,7 @@ const STATIC_ASSETS = [
 
 // Network-first resources (always try network first)
 const NETWORK_FIRST = [
-  '/assets/js/tracks.json',
+  '/assets/audio/tracks.json',
   '/contact.html',
   '/api/'
 ];

--- a/track-utils/constants.js
+++ b/track-utils/constants.js
@@ -1,6 +1,6 @@
 module.exports = {
-    TRACKS_PATH: 'assets/js/tracks.json',
-    MUSIC_JS_PATH: 'assets/js/music.js',
+    TRACKS_PATH: 'assets/audio/tracks.json',
+    MUSIC_JS_PATH: 'assets/js/pages/music.js',
     MUSIC_HTML_PATH: 'music.html',
     DEFAULT_ARTIST: 'Igor Szuniewicz',
     DEFAULT_SOURCE_TYPE: 'audio/wav'


### PR DESCRIPTION
## Summary
- update track management utilities to read the audio catalog from `assets/audio/tracks.json`
- ensure the service worker and project page load the relocated music script/data correctly

## Testing
- node list-tracks.js | head

------
https://chatgpt.com/codex/tasks/task_e_68d0286d44588321ab50526c541b03da