### PR TITLE
Fix Not Today Darling trailer autoplay and language switcher

### DIFF
--- a/assets/js/components/enhancements.js
+++ b/assets/js/components/enhancements.js
@@ -673,8 +673,8 @@ document.addEventListener('DOMContentLoaded', function() {
       box.appendChild(btn);
     });
     document.body.appendChild(box); return box; })();
-  // Hide fixed language switcher unless debug mode
-  try { fixedLang.style.display = DEBUG_MODE ? 'flex' : 'none'; } catch(_){}
+  // Ensure fixed language switcher stays visible across pages
+  try { fixedLang.style.display = 'flex'; } catch(_){ }
 
   function flagSvg(lang){
     // Use width/height 100% so parent spans can size the flag
@@ -787,6 +787,7 @@ document.addEventListener('DOMContentLoaded', function() {
     contact_reachout: { pl: 'Śmiało napisz z krótkim opisem. Lubię projekty łączące kreatywną wizję z rozwiązywaniem problemów technicznych.', nl: 'Stuur gerust een korte briefing. Ik werk graag aan projecten die creatieve intentie combineren met technische probleemoplossing.', en: 'Feel free to reach out with a short brief. I enjoy projects that combine creative intent with technical problem‑solving.' },
     // Not Today Darling page translations
     ntd_trailer_title: { pl: 'Trailer', nl: 'Trailer', en: 'Trailer' },
+    ntd_trailer_hint: { pl: '🎬 Obejrzyj trailer', nl: '🎬 Bekijk de trailer', en: '🎬 Watch the trailer' },
     ntd_role_title: { pl: 'Rola — Audio', nl: 'Rol — Audio', en: 'Role — Audio' },
     ntd_role_desc: { pl: 'Odpowiadałem za sound effects, implementację i miks: paleta SFX gameplayu, UI, warstwy crowd/ambience oraz integrację i miks w silniku dla czytelności przy szybkiej akcji. System reaguje na stany wyścigu i zdarzenia gracza.', nl: 'SFX‑ontwerp, implementatie en mix: gameplaypalet, UI, crowd/ambience, met engine‑integratie en mix voor leesbaarheid bij hoge snelheid. Systeem reageert op racestaten en events.', en: 'Handled SFX design, implementation and mixing: gameplay palette, UI, crowd/ambience, plus in‑engine integration and mix for clarity at speed. System reacts to race states and player events.' },
     ntd_hi_title: { pl: 'Gameplay Highlights', nl: 'Gameplay Highlights', en: 'Gameplay Highlights' },

--- a/assets/js/pages/not-today-darling.js
+++ b/assets/js/pages/not-today-darling.js
@@ -45,6 +45,39 @@
     });
   }
 
+  function setupTrailer(){
+    const wrapper = document.querySelector('.video-wrapper[data-video]');
+    if (!wrapper) return;
+    const thumb = wrapper.querySelector('.video-thumbnail');
+    const frame = wrapper.querySelector('iframe');
+    if (!thumb || !frame) return;
+    const base = frame.getAttribute('data-base') || wrapper.getAttribute('data-video') || '';
+    function activate(){
+      thumb.style.display = 'none';
+      frame.style.display = 'block';
+      if (!base) return;
+      const autoSrc = base.includes('autoplay=1') ? base : base + (base.includes('?') ? '&autoplay=1' : '?autoplay=1');
+      if (frame.dataset.loaded !== '1' || !frame.src || frame.src === 'about:blank'){
+        frame.src = autoSrc;
+        frame.dataset.loaded = '1';
+      } else if (!/autoplay=1/.test(frame.src)){
+        frame.src = frame.src + (frame.src.includes('?') ? '&' : '?') + 'autoplay=1';
+      }
+    }
+    thumb.addEventListener('click', activate);
+    thumb.addEventListener('keydown', (evt)=>{
+      if (evt.key === 'Enter' || evt.key === ' '){
+        evt.preventDefault();
+        activate();
+      }
+    });
+    thumb.setAttribute('role', 'button');
+    thumb.setAttribute('tabindex', '0');
+    if (!thumb.getAttribute('aria-label')){
+      thumb.setAttribute('aria-label', 'Play trailer');
+    }
+  }
+
   function enableRetroBackground(){
     document.addEventListener('DOMContentLoaded', function(){
       setTimeout(function(){ document.body.classList.add('retro-mode'); }, 500);
@@ -53,9 +86,10 @@
 
   // Init when DOM ready
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function(){ bindVoicelines(); enableRetroBackground(); });
+    document.addEventListener('DOMContentLoaded', function(){ bindVoicelines(); setupTrailer(); enableRetroBackground(); });
   } else {
     bindVoicelines();
+    setupTrailer();
     enableRetroBackground();
   }
 })();

--- a/projects/not-today-darling.html
+++ b/projects/not-today-darling.html
@@ -791,19 +791,23 @@
 
         <h3 id="bgColor" data-i18n="trailer_title" style="margin-top:1.5rem;">Trailer</h3>
         <div class="video-container" data-reveal>
-          <div class="video-wrapper" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; background: #000; border-radius: 8px; box-shadow: 0 12px 30px rgba(0,0,0,0.4);">
-            <div class="video-thumbnail" onclick="this.style.display='none'; this.nextElementSibling.style.display='block';" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; display: block;">
+          <div class="video-wrapper" data-video="https://www.youtube.com/embed/6lFEvyicea0?rel=0&modestbranding=1&color=white" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; background: #000; border-radius: 8px; box-shadow: 0 12px 30px rgba(0,0,0,0.4);">
+            <div class="video-thumbnail" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; display: block;">
               <img src="../assets/images/projects/NotTodayPic2.png?v=20250919b" alt="Not Today, Darling! Trailer" style="width: 100%; height: 100%; object-fit: cover;">
               <div class="play-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: linear-gradient(45deg, rgba(0,0,0,0.3), rgba(0,0,0,0.1)); backdrop-filter: blur(1px);"></div>
               <div class="play-button" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 90px; height: 90px; background: linear-gradient(135deg, #ff0844, #ff6b35); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 36px; color: white; box-shadow: 0 8px 25px rgba(255,8,68,0.4), 0 0 0 4px rgba(255,255,255,0.2); transition: all 0.3s ease; cursor: pointer;">
                 <div style="margin-left: 6px; text-shadow: 0 2px 4px rgba(0,0,0,0.3);">▶</div>
               </div>
-              <div class="play-hint" style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.7); color: white; padding: 8px 16px; border-radius: 20px; font-size: 0.9rem; font-weight: 500;">
+              <div class="play-hint" data-i18n="trailer_hint" style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.7); color: white; padding: 8px 16px; border-radius: 20px; font-size: 0.9rem; font-weight: 500;">
                 🎬 Obejrzyj trailer
               </div>
             </div>
-            <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; display: none;"
-              src="https://www.youtube.com/embed/6lFEvyicea0?autoplay=1&rel=0&modestbranding=1&color=white"
+            <iframe
+              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; display: none;"
+              src="about:blank"
+              data-base="https://www.youtube.com/embed/6lFEvyicea0?rel=0&modestbranding=1&color=white"
+              title="Not Today, Darling! trailer"
+              loading="lazy"
               frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowfullscreen>


### PR DESCRIPTION
## Summary
- prevent the Not Today, Darling! trailer from autoplaying by default and load it only after clicking the thumbnail
- add page logic to show the iframe on demand, support keyboard activation, and localize the trailer hint copy
- keep the floating language switcher visible on project pages so translations can be accessed everywhere

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d02f0727808321a6a5d8f3cb081acd