### PR TITLE
Fix language enhancements script path on project pages

### DIFF
--- a/projects/akantilado.html
+++ b/projects/akantilado.html
@@ -216,7 +216,7 @@
       </ul>
     </div>
   </div>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/theme-toggle.js"></script>
   <script>
     // Activate jungle background after page loads

--- a/projects/amorak.html
+++ b/projects/amorak.html
@@ -111,7 +111,7 @@
       </ul>
     </div>
   </div>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects/audio-plugin-suite.html
+++ b/projects/audio-plugin-suite.html
@@ -127,6 +127,6 @@
   <script src="../assets/js/breakpoints.min.js"></script>
   <script src="../assets/js/util.js"></script>
   <script src="../assets/js/main.js"></script>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
 </body>
 </html>

--- a/projects/audiolab.html
+++ b/projects/audiolab.html
@@ -416,7 +416,7 @@
   <script src="../assets/js/breakpoints.min.js"></script>
   <script src="../assets/js/util.js"></script>
   <script src="../assets/js/main.js"></script>
-  <script src="../assets/js/enhancements.js?v=20250919-fix"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250919-fix"></script>
 
 </body>
 </html>

--- a/projects/dynamic-music-system.html
+++ b/projects/dynamic-music-system.html
@@ -132,6 +132,6 @@
   <script src="../assets/js/breakpoints.min.js"></script>
   <script src="../assets/js/util.js"></script>
   <script src="../assets/js/main.js"></script>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
 </body>
 </html>

--- a/projects/musicforgames.html
+++ b/projects/musicforgames.html
@@ -585,7 +585,7 @@
   <script src="../assets/js/breakpoints.min.js"></script>
   <script src="../assets/js/util.js"></script>
   <script src="../assets/js/main.js"></script>
-  <script src="../assets/js/enhancements.js?v=20250919-fix"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250919-fix"></script>
 
 </body>
 </html>

--- a/projects/not-today-darling.html
+++ b/projects/not-today-darling.html
@@ -1051,7 +1051,7 @@
     </div>
   </div>
 
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/pages/music.js?v=20250926"></script>
   <script src="../assets/js/pages/not-today-darling.js" defer></script>
 </body>

--- a/projects/pause-and-deserve.html
+++ b/projects/pause-and-deserve.html
@@ -107,7 +107,7 @@
       </ul>
     </div>
   </div>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects/ray-animation.html
+++ b/projects/ray-animation.html
@@ -212,7 +212,7 @@
       </ul>
     </div>
   </div>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/theme-toggle.js"></script>
   <script>
     // Activate cave background after page loads

--- a/projects/richter.html
+++ b/projects/richter.html
@@ -107,7 +107,7 @@
       </ul>
     </div>
   </div>
-  <script src="../assets/js/enhancements.js?v=20250210"></script>
+  <script src="../assets/js/components/enhancements.js?v=20250210"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update every project detail page to reference the shared `assets/js/components/enhancements.js` bundle
- ensure the existing language switcher and translation logic loads across Ray, Akantilado, Amorak, Not Today Darling, and other project subpages

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d04fd544dc8321967a7c99d76cbd43